### PR TITLE
Installed babel-polyfill to resolve issue with Reflect not being found

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,6 +1,7 @@
 // @flow
 
 import 'es6-symbol/implement';
+import 'babel-polyfill'
 import React, {Component} from 'react';
 
 import Nav from './src/';

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@expo/vector-icons": "^5.0.0",
     "anymatch": "^1.3.0",
+    "babel-polyfill": "^6.26.0",
     "es6-symbol": "^3.1.1",
     "expo": "^19.0.0",
     "firebase": "^4.1.5",


### PR DESCRIPTION
The create team functionality was broken because Reflect was not found in data-sources\firebase-data-layer.js -> saveTeam.

It seems like adding the babel-polyfill addressed the issue though I'm not sure it's the best fix.