### PR TITLE
Enabled Team Editor screen Tab navigation icons on Android

### DIFF
--- a/screens/teams-screen/team-editor.js
+++ b/screens/teams-screen/team-editor.js
@@ -40,6 +40,10 @@ export default class TeamEditor extends Component {
             TeamEditorMap: {
                 screen: TeamEditorMap
             }
+        }, {
+            tabBarOptions: {
+                showIcon: true
+            }
         });
         return (
             <TeamEditorNav screenProps={{stacknav: this.props.navigation}}/>


### PR DESCRIPTION
I ran into this by accident and thought I'd fix it while at it. 

There's a screenshot below of how the screen looks like with the fix in place on Android. I assume this was the way it looked like on iOS before. There's a comment in code saying _" // Note: By default the icon is only shown on iOS. Search the showIcon option below."_

![screenshot_20180219-155249](https://user-images.githubusercontent.com/1213709/36396657-3e19ebee-158d-11e8-83f4-e004ee89ae8d.png)
