### PR TITLE
TabNavigator parity and other clean up

### DIFF
--- a/constants/Colors.js
+++ b/constants/Colors.js
@@ -1,14 +1,5 @@
-const tintColor = '#2f95dc';
-
 export default {
-  tintColor,
-  tabIconDefault: '#ccc',
-  tabIconSelected: tintColor,
-  tabBar: '#fefefe',
-  errorBackground: 'red',
-  errorText: '#fff',
-  warningBackground: '#EAEB5E',
-  warningText: '#666804',
-  noticeBackground: tintColor,
-  noticeText: '#fff',
+  tabIconDefault: '#fff',
+  tabIconSelected: 'lightgreen',
+  tabBarBackground: '#4a4b4c'
 };

--- a/navigation/MainTabNavigator.js
+++ b/navigation/MainTabNavigator.js
@@ -4,7 +4,6 @@ import {Ionicons} from '@expo/vector-icons';
 import {TabNavigator, TabBarBottom} from 'react-navigation';
 
 import Colors from '../constants/Colors';
-
 import MenuScreen from '../screens/menu-screen';
 import TeamsScreen from '../screens/teams-screen/';
 import MessagesScreen from '../screens/messages-screen/';
@@ -71,6 +70,16 @@ export default TabNavigator(
         tabBarComponent: TabBarBottom,
         tabBarPosition: 'bottom',
         animationEnabled: true,
-        swipeEnabled: false
+        swipeEnabled: false,
+        tabBarOptions: {
+          activeTintColor: Colors.tabIconSelected,
+          inactiveTintColor: Colors.tabIconDefault,
+        labelStyle: {
+          fontSize: 10
+        },
+        style: {
+          backgroundColor: Colors.tabBarBackground
+        }
     }
+  }
 );

--- a/screens/messages-screen/index.js
+++ b/screens/messages-screen/index.js
@@ -40,6 +40,10 @@ const myStyles = {
         color: '#333',
         padding: 10,
         margin: 10
+    },
+    loadingScreen: {
+      justifyContent: 'center',
+      alignItems: 'center'
     }
 };
 
@@ -189,8 +193,8 @@ class Messages extends Component {
         }
 
         return (
-            <View>
-                <Text>Running around, gathering data... please wait</Text>
+            <View style={[styles.container, styles.loadingScreen]}>
+                <Text>Loading...</Text>
             </View>
         );
     }

--- a/screens/teams-screen/team-editor-details.js
+++ b/screens/teams-screen/team-editor-details.js
@@ -21,6 +21,8 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 import DateTimePicker from 'react-native-modal-datetime-picker';
 import {SegmentedControls} from 'react-native-radio-buttons';
+
+import Colors from '../../constants/Colors';
 import * as actions from './actions';
 import {vermontTowns} from '../../libs/vermont-towns';
 import {defaultStyles} from '../../styles/default-styles';
@@ -50,7 +52,9 @@ class TeamEditorDetails extends Component {
         // Note: By default the icon is only shown on iOS. Search the showIcon option below.
         tabBarIcon: ({focused}) => (<Ionicons
             name={Platform.OS === 'ios' ? `ios-information-circle${focused ? '' : '-outline'}` : 'md-information'}
-            size={24} color='blue'/>)
+            size={24}
+            color={focused ? Colors.tabIconSelected : Colors.tabIconDefault}
+         />)
     };
 
     constructor(props) {

--- a/screens/teams-screen/team-editor-map.js
+++ b/screens/teams-screen/team-editor-map.js
@@ -17,6 +17,7 @@ import {connect} from 'react-redux';
 import MapView, {Polygon} from 'react-native-maps';
 import {Constants, Location, Permissions} from 'expo';
 
+import Colors from '../../constants/Colors';
 import {defaultStyles} from '../../styles/default-styles';
 import * as actions from './actions';
 
@@ -36,7 +37,7 @@ class TeamEditorMap extends Component {
         tabBarIcon: ({focused}) => (
             <Ionicons name={Platform.OS === 'ios' ? `ios-pin${focused ? '' : '-outline'}` : 'md-pin'}
                 size={24}
-                color='blue'
+                color={focused ? Colors.tabIconSelected : Colors.tabIconDefault}
             />)
     };
 

--- a/screens/teams-screen/team-editor-members.js
+++ b/screens/teams-screen/team-editor-members.js
@@ -63,21 +63,17 @@ class TeamEditorMembers extends Component {
 
     constructor(props) {
         super(props);
-        this.inviteContacts = this.inviteContacts.bind(this);
-        this.inviteForm = this.inviteForm.bind(this);
-        this.getIconColor = this.getIconColor.bind(this);
-        this._toMemberDetails = this._toMemberDetails.bind(this);
     }
 
-    inviteContacts() {
+    inviteContacts = () => {
         this.props.screenProps.stacknav.navigate('InviteContacts');
     }
 
-    inviteForm() {
+    inviteForm = () => {
         this.props.screenProps.stacknav.navigate('InviteForm');
     }
 
-    getIconColor(status) {
+    getIconColor = status => {
         switch (status) {
             case 'ACCEPTED':
                 return {
@@ -106,6 +102,22 @@ class TeamEditorMembers extends Component {
         }
     }
 
+    getStatusText = status => {
+        switch (status) {
+            case 'ACCEPTED':
+                return 'is on your team';
+            case 'OWNER':
+                return 'owns this team';
+            case 'INVITED':
+                return 'has been invited';
+            case 'NOT_INVITED':
+                return 'has not been invited';
+            case 'REQUEST_TO_JOIN':
+                return 'is requesting to join your team';
+            default:
+                return '';
+        }
+    }
     _toMemberDetails(teamId: string, membershipId: string) {
         return () => {
             this.props.screenProps.stacknav.navigate('TeamMemberDetails', {teamId, membershipId});
@@ -135,7 +147,7 @@ class TeamEditorMembers extends Component {
                     </View>
                 </TouchableHighlight>
                 <Text style={styles.memberName}>
-                    {(`${members[membershipId].displayName}`).trim()}
+                    {(`${members[membershipId].displayName} ${this.getStatusText(members[membershipId].memberStatus)}`).trim()}
                 </Text>
             </View>
 

--- a/screens/teams-screen/team-editor-members.js
+++ b/screens/teams-screen/team-editor-members.js
@@ -10,6 +10,7 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 import {Ionicons} from '@expo/vector-icons';
 
+import Colors from '../../constants/Colors';
 import * as actions from './actions';
 import * as memberStatus from '../../constants/team-member-statuses';
 import {defaultStyles} from '../../styles/default-styles';
@@ -57,7 +58,7 @@ class TeamEditorMembers extends Component {
         tabBarIcon: ({focused}) => (
             <Ionicons name={Platform.OS === 'ios' ? `ios-contacts${focused ? '' : '-outline'}` : 'md-contacts'}
                 size={24}
-                color='blue'
+                color={focused ? Colors.tabIconSelected : Colors.tabIconDefault}
             />)
     };
 

--- a/screens/teams-screen/team-editor.js
+++ b/screens/teams-screen/team-editor.js
@@ -2,8 +2,9 @@
 
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {TabNavigator} from 'react-navigation';
+import {TabNavigator, TabBarBottom} from 'react-navigation';
 
+import Colors from '../../constants/Colors';
 import TeamEditorDetails from './team-editor-details';
 import TeamEditorMap from './team-editor-map';
 import TeamEditorMembers from './team-editor-members';
@@ -49,10 +50,20 @@ export default class TeamEditor extends Component {
                 header: null
             }
         }, {
-            tabBarOptions: {
-                showIcon: true
-            },
+        tabBarComponent: TabBarBottom,
+        tabBarPosition: 'bottom',
             animationEnabled: true,
+            swipeEnabled: false,
+        tabBarOptions: {
+          activeTintColor: Colors.tabIconSelected,
+          inactiveTintColor: Colors.tabIconDefault,
+        labelStyle: {
+          fontSize: 10
+        },
+        style: {
+          backgroundColor: Colors.tabBarBackground
+        }
+        },
             initialRouteName: this.setDefault(status)
         });
         return (

--- a/styles/default-styles.js
+++ b/styles/default-styles.js
@@ -18,7 +18,7 @@ export const defaultStyles = {
         height: 40,
         padding: 5,
         textAlign: 'center',
-				lineHeight: 25
+        lineHeight: 25
     },
     fieldset: {
         borderWidth: 2,
@@ -62,7 +62,7 @@ export const defaultStyles = {
 			borderRadius: 20,
 			overflow: 'hidden',
       textAlign: 'center'
-		},
+    },
     heading1: {},
     heading2: {
         fontWeight: 'bold',
@@ -72,8 +72,8 @@ export const defaultStyles = {
         marginBottom: 10
     },
     label: {
-			marginTop: 5
-		},
+      marginTop: 5
+    },
     data: {
         fontWeight: 'bold'
     },
@@ -89,21 +89,21 @@ export const defaultStyles = {
         padding: 5,
         backgroundColor: 'darkseagreen'
     },
-		profileHeader: {
+    profileHeader: {
       flexDirection: 'row',
       justifyContent: 'flex-start',
       marginBottom: 10,
       borderWidth: 1,
       borderColor: '#000',
       backgroundColor: 'darkseagreen'
-  	},
-  	profileName: {
-    	paddingLeft: 10,
-    	paddingTop: 12.5,
-    	fontSize: 20,
-			color: '#fff',
-			textShadowColor: '#000',
-		  textShadowRadius: 2,
-			textShadowOffset: {width: 2 ,height: 2}
-  	}
+    },
+    profileName: {
+      paddingLeft: 10,
+      paddingTop: 12.5,
+      fontSize: 20,
+      color: '#fff',
+      textShadowColor: '#000',
+      textShadowRadius: 2,
+      textShadowOffset: {width: 2 ,height: 2}
+    }
 }


### PR DESCRIPTION
I made the two instances of tabNavigator work with the same options and point to the same color constants.  It's got higher contrast on purpose too.  The member status bit might not be MVP, but I thought it was a quick way to add clearer meaning to the icons in the member list.