### PR TITLE
Removed setting for following user location, hack to show location button

### DIFF
--- a/screens/trash-tracker-screen/trash-map.js
+++ b/screens/trash-tracker-screen/trash-map.js
@@ -112,10 +112,18 @@ class TrashMap extends Component {
             errorMessage: null,
             showCollectedTrash: false,
             showUncollectedTrash: true,
-            showTrashDropLocations: true
+            showTrashDropLocations: true,
+            hackyHeight: 300
         };
     }
 
+    componentWillMount() {
+        // Hack to work around known issue where the my location button doesn't show
+        // https://github.com/react-community/react-native-maps/issues/1332
+        setTimeout(( ) => this.setState({hackyHeight: 301}), 500);
+        setTimeout(() => this.setState({hackyHeight: 300}), 1000);
+
+    }
     componentDidMount() {
         if (!this.props.location) {
             this._getLocationAsync();
@@ -231,9 +239,8 @@ class TrashMap extends Component {
                             initialRegion={initialMapLocation}
                             showsUserLocation={true}
                             showsMyLocationButton={true}
-                            followsUserLocation={true}
                             showsCompass={true}
-                            style={{alignSelf: 'stretch', height: 300}}>
+                            style={{alignSelf: 'stretch', height: this.state.hackyHeight}}>
                             {drops && drops.filter(drop => (this.state.showCollectedTrash && drop.wasCollected === true) || (this.state.showUncollectedTrash && !drop.wasCollected)).map(drop => (
                                 <MapView.Marker
                                     key={drop.uid}


### PR DESCRIPTION
This is a fix for  https://github.com/johnneed/GreenUpVermont/issues/205.

@johnneed  I think I found the cause of the issue you were seeing on iOS with map following the user's location but I have no way to verify it works. Would you be able to check on your device?

I also added a hacky fix to display the location button on the map - this is a known issue with the library as documented [here](https://github.com/react-community/react-native-maps/issues/1332). I verified this works on Android but again I have no way of checking iOS. I think it something nice to have since we're anticipating the users will use the map quite a lot to look for other locations.