### PR TITLE
Using the MultiLineMapCallout to display areas claimed by other teams

### DIFF
--- a/screens/teams-screen/team-details.js
+++ b/screens/teams-screen/team-details.js
@@ -14,6 +14,7 @@ import {defaultStyles} from '../../styles/default-styles';
 import * as teamMemberStatuses from '../../constants/team-member-statuses';
 import {TeamMember} from '../../models/team-member';
 import {getMemberIcon} from '../../libs/member-icons';
+import MultiLineMapCallout from '../../components/MultiLineMapCallout';
 
 const myStyles =
     {
@@ -349,16 +350,18 @@ class TeamDetails extends Component {
                             {this.props.locations.length > 0 && this.props.locations.map((marker, index) => (
                                 <MapView.Marker
                                     coordinate={marker.coordinates}
-                                    key={index}
-                                    title={marker.title || 'clean area'}/>
+                                    key={index}>
+                                    <MultiLineMapCallout title={marker.title || 'clean area'} description='' />
+                                </MapView.Marker>
                             ))}
                             {this.props.otherCleanAreas.length > 0 && this.props.otherCleanAreas.map((a, i) =>
                                 (<MapView.Marker
                                     key={i}
                                     coordinate={a.coordinates}
-                                    image={otherTeamsLocationImage}
-                                    title={a.title}
-                                />))}
+                                    image={otherTeamsLocationImage}>
+                                    <MultiLineMapCallout title={a.title} description={a.description} />
+                                </MapView.Marker>
+                                ))}
                         </MapView>
                     </View>
                     {isTeamMember ? teamMemberList : null}
@@ -381,7 +384,8 @@ const mapStateToProps = (state) => ({
         .reduce((areas, team) => areas.concat(team.locations.map(l => Object.assign({}, {
             key: '',
             coordinates: l.coordinates,
-            title: `Claiming this area for team: ${team.name}`
+            title: `${team.name}`,
+            description: 'claimed this area'
         }))), [])
 });
 

--- a/screens/teams-screen/team-editor-map.js
+++ b/screens/teams-screen/team-editor-map.js
@@ -21,6 +21,7 @@ import {Constants, Location, Permissions} from 'expo';
 import Colors from '../../constants/Colors';
 import {defaultStyles} from '../../styles/default-styles';
 import * as actions from './actions';
+import MultiLineMapCallout from '../../components/MultiLineMapCallout';
 
 const myStyles = {};
 
@@ -153,7 +154,7 @@ class TeamEditorMap extends Component {
                     <Text>
                     Place markers in the area you want your team to work on.
                     Tap on the marker text box to remove a marker.
-                    Blue markers represent areas that other teams are cleaning up.
+                    Green flags represent areas that other teams are cleaning up.
                     </Text>
                     <MapView style={{alignSelf: 'stretch', height: '50%'}}
                         initialRegion={this.state.initialMapLocation}
@@ -161,18 +162,20 @@ class TeamEditorMap extends Component {
                         {this.props.locations.length > 0 && locations.map((marker, index) => (
                             <MapView.Marker coordinate={marker.coordinates}
                                 key={`location${index}`}
-                                title={marker.title || 'clean area'}
-                                onCalloutPress={this._removeMarker(marker)}
-                                description={marker.description || 'tap to remove'}
-                            />))}
+                                onCalloutPress={this._removeMarker(marker)}>
+                                <MultiLineMapCallout title={marker.title || 'clean area'} description={marker.description || 'tap to remove'} />
+                            </MapView.Marker>
+                        ))}
 
                         {otherCleanAreas.length > 0 && otherCleanAreas.map((a, i) =>
                             (<MapView.Marker
                                 key={i}
                                 coordinate={a.coordinates}
                                 image={otherTeamsLocationImage}
-                                title={a.title}
-                            />))}
+                                title={a.title}>
+                                <MultiLineMapCallout title={a.title} description={a.description} />
+                            </MapView.Marker>
+                            ))}
                     </MapView>
                     <View style={styles.button}>
                         <Button title={'remove marker'}
@@ -191,7 +194,8 @@ function mapStateToProps(state) {
         .reduce((areas, team) => areas.concat(team.locations.map(l => Object.assign({}, {
             key: '',
             coordinates: l.coordinates,
-            title: `Claiming this area for team: ${team.name}`
+            title: `${team.name}`,
+            description: 'claimed this area'
         }))), []);
     return {selectedTeam, locations, otherCleanAreas};
 }


### PR DESCRIPTION
Addressing https://github.com/johnneed/GreenUpVermont/issues/212

@johnneed I'm not sure this actually fixes what you wanted - I added the multi line callout to ensure text that is longer is no longer cut off. I also inverted the text and now displaying the team's name first 

e.g. 

> 
> **Smara's team**
> claimed this area