### PR TITLE
Stop propagation when clicking map markers

### DIFF
--- a/screens/teams-screen/team-details.js
+++ b/screens/teams-screen/team-details.js
@@ -295,7 +295,9 @@ class TeamDetails extends Component {
             (
                 <MapView.Marker
                     key={i + 1000}
-                    coordinate={a.coordinates}>
+                    coordinate={a.coordinates}
+                    pinColor={'yellow'}
+                    stopPropagation={true}>
                     <MultiLineMapCallout title={a.title || ''} description={a.description || ''}/>
                 </MapView.Marker>
             )
@@ -305,7 +307,8 @@ class TeamDetails extends Component {
         const teamAreas = (this.props.locations || []).map((marker, index) => (
             <MapView.Marker
                 coordinate={marker.coordinates}
-                key={index}>
+                key={index}
+                stopPropagation={true}>
                 <MultiLineMapCallout title={marker.title || 'clean area'} description={''}/>
             </MapView.Marker>
         )).concat(otherTeamAreas);

--- a/screens/teams-screen/team-editor-map.js
+++ b/screens/teams-screen/team-editor-map.js
@@ -163,7 +163,8 @@ class TeamEditorMap extends Component {
                                     <MapView.Marker coordinate={marker.coordinates}
                                         key={`location${index}`}
                                         pinColor={'red'}
-                                        onCalloutPress={this._removeMarker(marker)}>
+                                        onCalloutPress={this._removeMarker(marker)}
+                                        stopPropagation={true}>
                                         <MultiLineMapCallout title={marker.title || 'clean area'}
                                             description={marker.description || 'tap to remove'}/>
                                     </MapView.Marker>
@@ -174,7 +175,8 @@ class TeamEditorMap extends Component {
                                         coordinate={a.coordinates}
                                         // image={otherTeamsLocationImage}
                                         pinColor={'yellow'}
-                                        title={a.title}>
+                                        title={a.title}
+                                        stopPropagation={true}>
                                         <MultiLineMapCallout title={a.title} description={a.description}/>
                                     </MapView.Marker>
                                     ))}

--- a/screens/trash-tracker-screen/trash-map.js
+++ b/screens/trash-tracker-screen/trash-map.js
@@ -243,7 +243,7 @@ class TrashMap extends Component {
                 onCalloutPress={() => {
                     this.setState({modalVisible: true, drop: drop});
                 }}
-            />
+                stopPropagation={true}/>
         ));
 
         const myTrash = (drops || []).filter(drop => (this.state.showMyUncollectedTrash && !drop.wasCollected && drop.createdBy && drop.createdBy.uid === this.props.currentUser.uid)).map(drop => (
@@ -257,6 +257,7 @@ class TrashMap extends Component {
                 onCalloutPress={() => {
                     this.setState({modalVisible: true, drop: drop});
                 }}
+                stopPropagation={true}
             />
         ));
 
@@ -271,6 +272,7 @@ class TrashMap extends Component {
                 onCalloutPress={() => {
                     this.setState({modalVisible: true, drop: drop});
                 }}
+                stopPropagation={true}
             />
         ));
 
@@ -279,7 +281,8 @@ class TrashMap extends Component {
                 key={`${town}DropOffLocation${i}`}
                 // image={trashDropOffLocationIcon}
                 pinColor={'blue'}
-                coordinate={d.DropOffLocationCoordinates}>
+                coordinate={d.DropOffLocationCoordinates}
+                stopPropagation={true}>
                 <MultiLineMapCallout
                     title='Drop Off Location'
                     description={`${d.DropOffLocationName}, ${d.DropOffLocationAddress}`}
@@ -292,7 +295,8 @@ class TrashMap extends Component {
                 key={`supplyPickup${i}`}
                 // image={supplyPickupLocationIcon}
                 pinColor={'green'}
-                coordinate={d.PickupLocationCoordinates}>
+                coordinate={d.PickupLocationCoordinates}
+                stopPropagation={true}>
                 <MultiLineMapCallout
                     title='Supply Pickup Location'
                     description={`${d.PickupLocationName}, ${d.PickupLocationAddress}`}


### PR DESCRIPTION
This is a fix for https://github.com/johnneed/GreenUpVermont/issues/225.

I also set other team's pins color to yellow on the view team screen in order to be consistent with the edit team screen.